### PR TITLE
Make it easier to use an array of recipient to addresses

### DIFF
--- a/src/groovy/org/grails/mail/MailMessageBuilder.groovy
+++ b/src/groovy/org/grails/mail/MailMessageBuilder.groovy
@@ -75,11 +75,17 @@ class MailMessageBuilder {
         this.multipart = multipart
     }
 
-    void to(recip) {
+    void to(String recip) {
+      if(recip) {
+        to([recip] as String[])
+      }
+    }
+
+    void to(String[] recip) {
         if(recip) {
             if (ConfigurationHolder.config.grails.mail.overrideAddress)
                 recip = ConfigurationHolder.config.grails.mail.overrideAddress
-            getMessage().setTo([recip.toString()] as String[])
+            getMessage().setTo(recip)
         }
     }
 


### PR DESCRIPTION
This seemed like a sensible enhancement to the API to make it easier to use an array of recipient to addresses. No matter how I tried to do a toArray() per the documentation, the recip.toString() call in the original code was foiling my attempts to send to multiple email addresses.
