### PR TITLE
Mail plugin docs copied from grails.org plugin page

### DIFF
--- a/src/docs/guide/1. Introduction.gdoc
+++ b/src/docs/guide/1. Introduction.gdoc
@@ -4,12 +4,12 @@ Mail can be sent using the @mailService@ via the @sendMail@ method. Here is an e
 
 {code}
 mailService.sendMail {
-   to "fred@gmail.com","ginger@gmail.com"
+   to "fred@gmail.com", "ginger\@gmail.com"
    from "john@gmail.com"
-   cc "marge@gmail.com", "ed@gmail.com"
+   cc "marge@gmail.com", "ed\@gmail.com"
    bcc "joe@gmail.com"
    subject "Hello John"
-   text 'this is some text'
+   text "this is some text"
 }
 {code}
 
@@ -21,6 +21,6 @@ The @sendMail@ method is injected into all controllers to simplify access:
 sendMail {
    to "fred@g2one.com"
    subject "Hello Fred"
-   text 'How are you?'
+   text "How are you?"
 }
 {code}

--- a/src/docs/guide/3. Sending Email.gdoc
+++ b/src/docs/guide/3. Sending Email.gdoc
@@ -4,7 +4,7 @@ To send HTML mail you can use the @html@ method instead of the @body@ method:
 sendMail {
   to "fred@g2one.com"
   subject "Hello John"
-  html '<b>Hello</b> World'
+  html "<b>Hello</b> World"
 }
 {code}
 
@@ -14,28 +14,28 @@ If your HTML is contained within a GSP template you can use the render tag calle
 sendMail {
   to "john@g2one.com"
   subject "Hello John"
-  html g.render(template:"myMailTemplate")
+  html g.render(template: "myMailTemplate")
 }
 {code}
 
-If you wish to render a mail body from a GSP view from anywhere in your application, including from services or jobs where there may or may not be a current request, you can use the new body method variant (v0.4):
+If you wish to render a mail body from a GSP view from anywhere in your application, including from services or jobs where there may or may not be a current request, you can pass a view, model, and optional plugin to the @html@ method:
 
 {code}
 sendMail {
   to "john@g2one.com"
   subject "Hello John"
-  html( view:"/emailconfirmation/mail/confirmationRequest",
-      plugin:"email-confirmation",
-      model:[fromAddress:'bill@microsoft.com'])
+  html(view: "/emailconfirmation/mail/confirmationRequest",
+      plugin: "email-confirmation",
+      model: [fromAddress: "bill@microsoft.com"])
 }
 {code}
 
-The view is the absolute path (or relative if you have a current controller) to the GSP. The plugin parameter is optional - if you need to render a template that may exist in a plugin installed in your application, you must include the name here. The model parameter is a map representing the model the GSP will see for rendering data.
+The view is the absolute path (or relative if you have a current controller) to the GSP. If you need to render a template that may exist in a plugin installed in your application, you must include the name in the plugin parameter. The model parameter is a map representing the model the GSP will see for rendering data.
 
 The content-type is always set to text/html when using the @html@ method. When using the @body@ method, the content-type defaults to text/plain, so you must include the GSP page contentType directive at the top of the GSP for a HTML email:
 
 {code}
-<%@ page contentType="text/html"%>
+<%\@ page contentType="text/html" %>
 {code}
 
 This plugin also accepts emails in the form "Bill Gates<bill@microsoft.com>". This allows you to specify the sender display name in mail clients.
@@ -46,7 +46,7 @@ You can send mail to multiple recipients (in either of 'to', 'cc' or 'bcc') at o
 
 {code}
 sendMail {
-    to "fred@g2one.com","ginger@g2one.com"
+    to "fred\@g2one.com", "ginger@g2one.com"
     subject "Hello to mutliple recipients"
     body "Hello Fred! Hello Ginger!"
 }


### PR DESCRIPTION
I've copied the usage examples from http://www.grails.org/plugin/mail into the plugin docs and applied gdoc formatting.

I will do much more work on the docs this weekend. I need to add more examples, remove outdated warnings, explain the available methods in the sendMail closure, and fix a few formatting glitches.

Apologies if I've fouled up the commit--I'm just getting started with git/github.
