### PR TITLE
Allow using closure argument in sendMail method

### DIFF
--- a/grails-app/services/grails/plugin/mail/MailService.groovy
+++ b/grails-app/services/grails/plugin/mail/MailService.groovy
@@ -36,7 +36,7 @@ class MailService {
         def messageBuilder = mailMessageBuilderFactory.createBuilder(mailConfig)
         callable.delegate = messageBuilder
         callable.resolveStrategy = Closure.DELEGATE_FIRST
-        callable.call()
+        callable.call(messageBuilder)
 
         messageBuilder.sendMessage()
     }


### PR DESCRIPTION
Allow writing:

```
mailService.sendMail {
  it.from 'abc@example.com'
  it.to 'def@example.com'
  it.subject 'test'
  it.text 'some text'
}
```

instead of:

```
mailService.sendMail {
  from 'abc@example.com'
  to 'def@example.com'
  subject 'test'
  text 'some text'
}
```

It can be sometimes more convenient and can solve problem with clashing variable names like `subject`.
