### PR TITLE
Default configuration for cc and bcc

### DIFF
--- a/src/docs/guide/2.2 Defaults Configuration.gdoc
+++ b/src/docs/guide/2.2 Defaults Configuration.gdoc
@@ -12,6 +12,12 @@ You can also set the default "to" address to use for messages in Config using:
 grails.mail.default.to = "user@yourhost.com"
 {code}
 
+You can also set the default "cc" address to use for messages in Config using:
+
+{code}
+grails.mail.default.cc = "user@yourhost.com"
+{code}
+
 You can also set the default "bcc" address to use for messages in Config using:
 
 {code}

--- a/src/docs/guide/2.2 Defaults Configuration.gdoc
+++ b/src/docs/guide/2.2 Defaults Configuration.gdoc
@@ -11,3 +11,9 @@ You can also set the default "to" address to use for messages in Config using:
 {code}
 grails.mail.default.to = "user@yourhost.com"
 {code}
+
+You can also set the default "bcc" address to use for messages in Config using:
+
+{code}
+grails.mail.default.bcc = "user@yourhost.com"
+{code}

--- a/src/groovy/grails/plugin/mail/MailMessageBuilder.groovy
+++ b/src/groovy/grails/plugin/mail/MailMessageBuilder.groovy
@@ -52,6 +52,7 @@ class MailMessageBuilder {
     final String defaultFrom
     final String defaultTo
     final String defaultBcc
+    final String defaultCc
     final String overrideAddress
 
     private MailMessage message
@@ -81,6 +82,7 @@ class MailMessageBuilder {
         this.defaultFrom = overrideAddress ?: (config.default.from ?: null)
         this.defaultTo = overrideAddress ?: (config.default.to ?: null)
         this.defaultBcc = overrideAddress ?: (config.default.bcc ?: null)
+        this.defaultCc = overrideAddress ?: (config.default.cc ?: null)
     }
 
     private MailMessage getMessage() {
@@ -102,6 +104,10 @@ class MailMessageBuilder {
 
             if (defaultBcc) {
                 message.setBcc(defaultBcc)
+            }
+
+            if (defaultCc) {
+                message.setCc(defaultCc)
             }
         }
 

--- a/src/groovy/grails/plugin/mail/MailMessageBuilder.groovy
+++ b/src/groovy/grails/plugin/mail/MailMessageBuilder.groovy
@@ -51,6 +51,7 @@ class MailMessageBuilder {
 
     final String defaultFrom
     final String defaultTo
+    final String defaultBcc
     final String overrideAddress
 
     private MailMessage message
@@ -79,6 +80,7 @@ class MailMessageBuilder {
         this.overrideAddress = config.overrideAddress ?: null
         this.defaultFrom = overrideAddress ?: (config.default.from ?: null)
         this.defaultTo = overrideAddress ?: (config.default.to ?: null)
+        this.defaultBcc = overrideAddress ?: (config.default.bcc ?: null)
     }
 
     private MailMessage getMessage() {
@@ -96,6 +98,10 @@ class MailMessageBuilder {
 
             if (defaultTo) {
                 message.setTo(defaultTo)
+            }
+
+            if (defaultBcc) {
+                message.setBcc(defaultBcc)
             }
         }
 

--- a/test/unit/grails/plugin/mail/MailMessageBuilderTests.groovy
+++ b/test/unit/grails/plugin/mail/MailMessageBuilderTests.groovy
@@ -37,11 +37,15 @@ class MailMessageBuilderTests extends GroovyTestCase {
 
     private String defaultFrom = "from@grailsplugin.com"
     private String defaultTo = "to@grailsplugin.com"
+    private String defaultBcc = "bcc@grailsplugin.com"
+    private String defaultCc = "cc@grailsplugin.com"
 
     protected void setUp() {
         def config = new ConfigObject()
         config.default.from = defaultFrom
         config.default.to = defaultTo
+        config.default.bcc = defaultBcc
+        config.default.cc = defaultCc
 
         def mockJavaMailSender = [
             createMimeMessage: {-> new MimeMessage(Session.getInstance(new Properties())) }
@@ -160,6 +164,26 @@ class MailMessageBuilderTests extends GroovyTestCase {
         def msg = testJavaMailSenderBuilder.message.mimeMessage
         assertEquals defaultTo, to(msg)[0].toString()
         assertEquals defaultFrom, msg.from[0].toString()
+    }
+
+    void testDefaultBcc() {
+        processDsl {
+            subject "Hello Fred"
+            body 'How are you?'
+        }
+
+        def msg = testJavaMailSenderBuilder.message.mimeMessage
+        assertEquals defaultBcc, bcc(msg)[0].toString()
+    }
+
+    void testDefaultCc() {
+        processDsl {
+            subject "Hello Fred"
+            body 'How are you?'
+        }
+
+        def msg = testJavaMailSenderBuilder.message.mimeMessage
+        assertEquals defaultCc, cc(msg)[0].toString()
     }
 
     void testEnvelopeFrom() {


### PR DESCRIPTION
I've implemented (following the examples of from and to) a way to specify a default configuration for bcc field. Could you please review and accept this change? Thanks.
