### PR TITLE
Fixed assertion check to allow headers to be empty

### DIFF
--- a/src/groovy/grails/plugin/mail/MailMessageBuilder.groovy
+++ b/src/groovy/grails/plugin/mail/MailMessageBuilder.groovy
@@ -163,7 +163,7 @@ class MailMessageBuilder {
     }
 
     void headers(Map hdrs) {
-        Assert.notEmpty(hdrs, "headers cannot be null")
+        Assert.notNull(hdrs, "headers cannot be null")
 
         // The message must be of type MimeMailMessage to add headers.
         if (!mimeCapable) {


### PR DESCRIPTION
The assertion for the `headers` DLS field checks to see if the map is not empty, but then throws the error "headers cannot be null". I believe this assertion is in error and it should use `Assert.notNull()` instead. This allows the passing of empty header lists and in addition produces a correct error message.

Note that I have not tested this change.