### PR TITLE
fix(deps): set compileOnly dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,16 +21,18 @@ repositories {
 
 dependencies {
 
-    api libs.groovy.core // Used in public api
+    compileOnly libs.grails.core // Used in public api, but provided
+    compileOnly libs.groovy.core // Used in public api, but provided
+    compileOnly libs.servlet.api // Provided
+
     api libs.javamail.api // Used in public api
     api libs.spring.context // Used in public api
     api libs.spring.context.support // Used in public api
 
-    // These three libraries are used in public api, but not in a way
+    // These two libraries are used in public api, but not in a way
     // that is meant to be consumed by users of the plugin.
     // Therefore they are set to implementation to not expose unnecessarily
     // to the compileClasspath of plugin users.
-    implementation libs.grails.core
     implementation libs.grails.gsp
     implementation libs.grails.web.common
 
@@ -40,6 +42,7 @@ dependencies {
     implementation libs.springboot.autoconfigure
 
     testImplementation libs.grails.testing.support.core
+    testImplementation libs.servlet.api
     testImplementation libs.spock.core
 
     integrationTestImplementation libs.groovy.xml

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ greenmail = '2.0.1'
 groovy = '4.0.23'
 gsp = '7.0.0-SNAPSHOT'
 javamail = '2.0.1'
+servlet-api = '6.0.0'
 slf4j = '1.7.36'
 spring = '6.1.13'
 springboot = '3.3.4'
@@ -22,6 +23,7 @@ groovy-core = { module = 'org.apache.groovy:groovy', version.ref = 'groovy' }
 grails-docs = { module = 'org.grails:grails-docs', version.ref = 'grails' }
 groovy-templates = { module = 'org.apache.groovy:groovy-templates', version.ref = 'groovy' }
 groovy-xml = { module = 'org.apache.groovy:groovy-xml', version.ref = 'groovy' }
+servlet-api = { module = 'jakarta.servlet:jakarta.servlet-api', version.ref = 'servlet-api' }
 javamail-api = { module = 'jakarta.mail:jakarta.mail-api', version.ref = 'javamail' }
 javamail-impl = { module = 'com.sun.mail:jakarta.mail', version.ref = 'javamail' }
 slf4j-nop = { module = 'org.slf4j:slf4j-nop', version.ref = 'slf4j' }


### PR DESCRIPTION
The `jakarta-servlet-api` was previously included as a transitive dependency, but it is no longer available through that path. To resolve the issue, this commit explicitly adds `jakarta-servlet-api` as a `compileOnly` dependency to ensure the necessary classes are available during compilation without bundling them into the final artifact.

Also change scopes of `groovy` and `grails-core` dependencies to `compileOnly` as these will always be provided to a grails plugin.