### PR TITLE
Remove `slf4j-simple` from `testRuntimeClasspath`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,6 @@ dependencies {
     implementation libs.spring.beans
     implementation libs.springboot.autoconfigure
 
-    testRuntimeOnly libs.slf4j.simple
-
     testImplementation libs.servlet.api
     testImplementation libs.grails.testingSupport.core
     testImplementation libs.spock.core

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,6 @@ servlet-api = { module = 'jakarta.servlet:jakarta.servlet-api' }
 javamail-api = { module = 'jakarta.mail:jakarta.mail-api' }
 javamail-impl = { module = 'org.eclipse.angus:jakarta.mail' }
 slf4j-nop = { module = 'org.slf4j:slf4j-nop' }
-slf4j-simple = { module = 'org.slf4j:slf4j-simple' }
 spock-core = { module = 'org.spockframework:spock-core' }
 spring-beans = { module = 'org.springframework:spring-beans' }
 spring-context = { module = 'org.springframework:spring-context' }


### PR DESCRIPTION
Because:
```console
LoggerFactory is not a Logback LoggerContext but Logback is on the classpath. Either remove Logback or the competing implementation (class org.slf4j.simple.SimpleLoggerFactory loaded from file:/home/mattias/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-simple/2.0.16/56d3d8e59293543780ad35af4ee4a5d9c111a588/slf4j-simple-2.0.16.jar). If you are using WebLogic you will need to add 'org.slf4j' to prefer-application-packages in WEB-INF/weblogic.xml: org.slf4j.simple.SimpleLoggerFactory
```