### PR TITLE
Fix CI workflows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,8 +7,8 @@ on:
     branches:
       - '[4-9]+.[0-9]+.x'
 env:
-  GIT_USER_NAME: puneetbehl
-  GIT_USER_EMAIL: behlp@unityfoundation.io
+  GIT_USER_NAME: ${{ secrets.GIT_USER_NAME }}
+  GIT_USER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
 
 jobs:
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
       - name: Run tests
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: ./gradlew check
 
   publish_snapshot:
@@ -48,13 +48,13 @@ jobs:
 
       - name: Build Project
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: ./gradlew build
 
       - name: Publish Snapshot version to Artifactory (repo.grails.org)
         if: success()
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           ORG_GRADLE_PROJECT_artifactoryPublishUsername: ${{ secrets.ARTIFACTORY_USERNAME }}
           ORG_GRADLE_PROJECT_artifactoryPublishPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
         run: >
@@ -65,7 +65,7 @@ jobs:
       - name: Generate Snapshot Documentation
         if: success()
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: ./gradlew docs
 
       - name: Publish Snapshot Documentation to Github Pages

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,51 +1,23 @@
-name: Changelog
+name: "Release Drafter"
 on:
   issues:
-    types: [closed,reopened]
+    types: [closed, reopened]
   push:
     branches:
+      - master
       - '[4-9]+.[0-9]+.x'
   pull_request:
-    types: [opened, reopened, synchronize, labeled]
+    types: [opened, reopened, synchronize]
   pull_request_target:
-    types: [opened, reopened, synchronize, labeled]       
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 jobs:
-  release_notes:
+  update_release_draft:
+    permissions:
+      contents: read # limit to read access
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Check if it has release drafter config file
-        id: check_release_drafter
-        run: |
-          has_release_drafter=$([ -f .github/release-drafter.yml ] && echo "true" || echo "false")
-          echo "has_release_drafter=${has_release_drafter}" >> $GITHUB_OUTPUT
-      - name: Extract branch name
-        id: extract_branch
-        run: echo "value=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
-      # If it has release drafter:
-      - uses: release-drafter/release-drafter@v5
-        if: steps.check_release_drafter.outputs.has_release_drafter == 'true'
+      - name: "📝 Update Release Draft"
+        uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        with:
-          commitish: ${{ steps.extract_branch.outputs.value }}
-      # Otherwise:
-      - name: Export Gradle Properties
-        if: steps.check_release_drafter.outputs.has_release_drafter == 'false'
-        uses: micronaut-projects/github-actions/export-gradle-properties@master
-      - uses: micronaut-projects/github-actions/release-notes@master
-        if: steps.check_release_drafter.outputs.has_release_drafter == 'false'
-        id: release_notes
-        with:
-          token: ${{ secrets.GH_TOKEN }}
-      - uses: ncipollo/release-action@v1
-        if: steps.check_release_drafter.outputs.has_release_drafter == 'false' && steps.release_notes.outputs.generated_changelog == 'true'
-        with:
-          allowUpdates: true
-          commit: ${{ steps.release_notes.outputs.current_branch }}
-          draft: true
-          name: "${{ env.title }} ${{ steps.release_notes.outputs.next_version }}"
-          tag: v${{ steps.release_notes.outputs.next_version }}
-          bodyFile: CHANGELOG.md
-          token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Publish artifacts to Sonatype
         id: publish_to_sonatype
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_sonatypeStagingProfileId: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
@@ -47,7 +47,7 @@ jobs:
       - name: Generate Documentation
         if: success()
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: ./gradlew docs
 
       - name: Publish Documentation to Github Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ on:
   release:
     types: [published]
 env:
-  GIT_USER_NAME: puneetbehl
-  GIT_USER_EMAIL: behlp@unityfoundation.io
+  GIT_USER_NAME: ${{ secrets.GIT_USER_NAME }}
+  GIT_USER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
 
 jobs:
   release:

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -6,7 +6,7 @@ ext.set('signing.password', findProperty('signing.password') ?: System.getenv('S
 def javaComponent = components.named('java')
 publishing {
     publications {
-        register('grailsMailPlugin', MavenPublication) {
+        create('grailsMailPlugin', MavenPublication) {
             from javaComponent.get()
             versionMapping {
                 usage('java-api') { fromResolutionOf('runtimeClasspath') }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -6,7 +6,7 @@ ext.set('signing.password', findProperty('signing.password') ?: System.getenv('S
 def javaComponent = components.named('java')
 publishing {
     publications {
-        create('grailsMailPlugin', MavenPublication) {
+        register('grailsMailPlugin', MavenPublication) {
             from javaComponent.get()
             versionMapping {
                 usage('java-api') { fromResolutionOf('runtimeClasspath') }


### PR DESCRIPTION
This PR will:
- Update the Git user for CI operations to the one set in the organization secrets. At present that user is `gpc-deploy`.
- Switch to the correct secret for `DEVELOCITY_ACCESS_KEY`
- Fix release-drafter.yml