### PR TITLE
build: add dependency on the GSP Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,11 @@ dependencies {
     implementation libs.spring.beans
     implementation libs.springboot.autoconfigure
 
+    runtimeOnly libs.grails.plugin.gsp, {
+        // The GSP Plugin registers the GroovyPagesTemplateEngine and
+        // GroovyPagesUriService Beans that are injected in MailConfiguration.
+    }
+
     testImplementation libs.grails.testing.support.core
     testImplementation libs.spock.core
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ spock = '2.3-groovy-3.0'
 [libraries]
 grails-core = { module = 'org.grails:grails-core', version.ref = 'grails' }
 grails-gsp = { module = 'org.grails:grails-gsp', version.ref = 'gsp' }
+grails-plugin-gsp = { module = 'org.grails.plugins:gsp', version.ref = 'gsp' }
 grails-testing-support-core = { module = 'org.grails:grails-testing-support', version.ref = 'grails-testing-support' }
 grails-testing-support-web = { module = 'org.grails:grails-web-testing-support', version.ref = 'grails-testing-support' }
 grails-web-common = { module = 'org.grails:grails-web-common', version.ref = 'grails' }


### PR DESCRIPTION
We need the `GroovyPagesTemplateEngine` and `GroovyPagesUriService` beans registered as they are injected in `MailConfiguration`.