### PR TITLE
Allow for overriding MailService properties for easier testing

### DIFF
--- a/src/main/groovy/grails/plugins/mail/MailService.groovy
+++ b/src/main/groovy/grails/plugins/mail/MailService.groovy
@@ -37,13 +37,13 @@ import java.util.concurrent.TimeUnit
 @CompileStatic
 class MailService implements InitializingBean, DisposableBean {
 
-    private final MailConfigurationProperties mailConfigurationProperties
-    private final MailMessageBuilderFactory mailMessageBuilderFactory
+    protected MailConfigurationProperties mailConfigurationProperties
+    protected MailMessageBuilderFactory mailMessageBuilderFactory
 
-    private ThreadPoolExecutor mailExecutorService
+    protected ThreadPoolExecutor mailExecutorService
 
-    private static final Integer DEFAULT_POOL_SIZE = 5
-    private static final Bindable<MailConfigurationProperties> CONFIG_BINDABLE = Bindable.of(MailConfigurationProperties)
+    protected static final Integer DEFAULT_POOL_SIZE = 5
+    protected static final Bindable<MailConfigurationProperties> CONFIG_BINDABLE = Bindable.of(MailConfigurationProperties)
 
     MailService(
             MailConfigurationProperties mailConfigurationProperties,


### PR DESCRIPTION
I've been updating my application and noticed the significant refactoring to the mail service.  Currently there are private methods that should be protected to make it easier to override / enhance / replace the mail service functionality.  This PR changes them to protected so a different implementation can be used.